### PR TITLE
MLPAB-631 - Set email backend to dummy

### DIFF
--- a/terraform/modules/weblate/app/ecs.tf
+++ b/terraform/modules/weblate/app/ecs.tf
@@ -196,10 +196,10 @@ locals {
           name = "WEBLATE_REQUIRE_LOGIN",
           value = tostring(var.app_env_vars.weblate_require_login)
         },
-        {
-          name = "WEBLATE_BASIC_LANGUAGES",
-          value = tostring(var.app_env_vars.weblate_basic_languages)
-        },
+        # {
+        #   name = "WEBLATE_BASIC_LANGUAGES",
+        #   value = tostring(var.app_env_vars.weblate_basic_languages)
+        # },
         {
           name = "WEBLATE_RATELIMIT_ATTEMPTS",
           value = tostring(var.app_env_vars.weblate_ratelimit_attempts)
@@ -268,10 +268,10 @@ locals {
           name = "WEBLATE_EMAIL_USE_SSL",
           value = tostring(var.app_env_vars.weblate_email_use_ssl)
         },
-        {
-          name = "WEBLATE_EMAIL_USE_TLS",
-          value = tostring(var.app_env_vars.weblate_email_use_tls)
-        },
+        # {
+        #   name = "WEBLATE_EMAIL_USE_TLS",
+        #   value = tostring(var.app_env_vars.weblate_email_use_tls)
+        # },
         {
           name = "WEBLATE_EMAIL_BACKEND",
           value = tostring(var.app_env_vars.weblate_email_backend)

--- a/terraform/modules/weblate/ecs.tf
+++ b/terraform/modules/weblate/ecs.tf
@@ -24,7 +24,7 @@ module "app" {
   ecs_cluster                    = aws_ecs_cluster.main.id
   ecs_execution_role             = aws_iam_role.execution_role
   ecs_task_role                  = aws_iam_role.app_task_role
-  ecs_service_desired_count      = 0
+  ecs_service_desired_count      = 1
   ecs_application_log_group_name = module.application_logs.cloudwatch_log_group.name
   ecs_capacity_provider          = var.ecs_capacity_provider
   app_env_vars                   =  local.weblate_docker_configuration

--- a/terraform/modules/weblate/variables.tf
+++ b/terraform/modules/weblate/variables.tf
@@ -2,17 +2,18 @@ locals {
   name_prefix = "${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.name}"
 
   weblate_docker_configuration = {
-    weblate_loglevel = 0 # 0 = DEBUG, 1 = INFO, 2 = WARNING, 3 = ERROR, 4 = CRITICAL
-    weblate_loglevel_database = 0 # 0 = DEBUG, 1 = INFO, 2 = WARNING, 3 = ERROR, 4 = CRITICAL
+    weblate_loglevel = "DEBUG"
+    weblate_loglevel_database = "DEBUG"
     weblate_site_title = "OPG Weblate"
     weblate_site_domain = aws_route53_record.app.fqdn
     weblate_admin_name = "opg-weblate"
+    weblate_admin_email = "noreply@example.com"
     weblate_registration_open = 0
     weblate_allowed_hosts = aws_route53_record.app.fqdn
     weblate_time_zone = "Europe/London"
     weblate_enable_https = 1
     weblate_require_login = 1
-    weblate_basic_languages = ""
+    # weblate_basic_languages = "" # This only limits non privileged users to add unwanted languages. The project admins are still presented with full selection of languages defined in Weblate.
     weblate_ratelimit_attempts = 5
     weblate_ratelimit_lockout = 300
     weblate_ratelimit_window = 600
@@ -27,12 +28,12 @@ locals {
     redis_host = "cache"
     redis_port = 6379
     redis_db = 1
-    weblate_email_host = ""
-    weblate_email_port = ""
-    weblate_email_host_user = ""
-    weblate_email_use_ssl = ""
-    weblate_email_use_tls = ""
-    weblate_email_backend = ""
+    weblate_email_backend = "django.core.mail.backends.dummy.EmailBackend" # "django.core.mail.backends.smtp.EmailBackend". To disable sending e-mails by Weblate set EMAIL_BACKEND to django.core.mail.backends.dummy.EmailBackend. see https://docs.weblate.org/en/latest/admin/install.html#production-email
+    weblate_email_host = "smtp.example.com"
+    weblate_email_port = 587 # 587 = STARTTLS, 465 = TLS Wrapper see https://docs.aws.amazon.com/ses/latest/dg/smtp-connect.html
+    weblate_email_host_user = "user"
+    weblate_email_use_ssl = 1 # one or other of these are set in ecs container definition
+    weblate_email_use_tls = 1 # one or other of these are set in ecs container definition
   }
 }
 


### PR DESCRIPTION
# Purpose

Deactivate email sending for the service until we're ready to set it up

Fixes MLPAB-631

## Approach

- set email backend to `dummy`

## Learning

- https://docs.weblate.org/en/latest/admin/install.html#production-email
