### PR TITLE
MLPAB-651 - pull github credentials from AWS secrets manager

### DIFF
--- a/terraform/environment/pr_environments/main.tf
+++ b/terraform/environment/pr_environments/main.tf
@@ -5,7 +5,7 @@ module "weblate" {
   ecs_capacity_provider           = "FARGATE_SPOT"
   ecs_service_desired_count       = 1
   weblate_repository_url          = "weblate/weblate"
-  weblate_container_version       = "latest"
+  weblate_container_version       = "bleeding"
   alb_deletion_protection_enabled = false
 
   providers = {

--- a/terraform/environment/pr_environments/main.tf
+++ b/terraform/environment/pr_environments/main.tf
@@ -5,7 +5,7 @@ module "weblate" {
   ecs_capacity_provider           = "FARGATE_SPOT"
   ecs_service_desired_count       = 1
   weblate_repository_url          = "weblate/weblate"
-  weblate_container_version       = "bleeding"
+  weblate_container_version       = "4.15.2-3"
   alb_deletion_protection_enabled = false
 
   providers = {

--- a/terraform/modules/weblate/app/ecs.tf
+++ b/terraform/modules/weblate/app/ecs.tf
@@ -201,6 +201,11 @@ locals {
           name      = "WEBLATE_EMAIL_HOST_PASSWORD",
           valueFrom = var.app_secrets_arns.weblate_email_host_password
         },
+        # {
+        #   name      = "GITHUB_CREDENTIALS",
+        #   valueFrom = "${var.app_secrets_arns.weblate_github}"
+        # },
+        # },
         {
           name      = "WEBLATE_GITHUB_USERNAME",
           valueFrom = "${var.app_secrets_arns.weblate_github}:weblate_github_username::"
@@ -208,6 +213,10 @@ locals {
         {
           name      = "WEBLATE_GITHUB_TOKEN",
           valueFrom = "${var.app_secrets_arns.weblate_github}:weblate_github_token::"
+        },
+        {
+          name      = "WEBLATE_GITHUB_HOST",
+          valueFrom = "${var.app_secrets_arns.weblate_github}:weblate_github_host::"
         },
       ],
       environment = [

--- a/terraform/modules/weblate/app/ecs.tf
+++ b/terraform/modules/weblate/app/ecs.tf
@@ -193,19 +193,10 @@ locals {
           name      = "POSTGRES_PASSWORD",
           valueFrom = var.app_secrets_arns.postgres_password
       },
-      #   {
-      #     name      = "REDIS_PASSWORD",
-      #     valueFrom = var.app_secrets_arns.redis_password
-      # },
         {
           name      = "WEBLATE_EMAIL_HOST_PASSWORD",
           valueFrom = var.app_secrets_arns.weblate_email_host_password
         },
-        # {
-        #   name      = "GITHUB_CREDENTIALS",
-        #   valueFrom = "${var.app_secrets_arns.weblate_github}"
-        # },
-        # },
         {
           name      = "WEBLATE_GITHUB_USERNAME",
           valueFrom = "${var.app_secrets_arns.weblate_github}:weblate_github_username::"
@@ -296,10 +287,6 @@ locals {
           name = "POSTGRES_SSL_MODE",
           value = tostring(var.app_env_vars.postgres_ssl_mode)
         },
-        # {
-        #   name = "POSTGRES_ALTER_ROLE",
-        #   value = tostring(var.app_env_vars.postgres_alter_role)
-        # },
         {
           name = "POSTGRES_CONN_MAX_AGE",
           value = tostring(var.app_env_vars.postgres_conn_max_age)

--- a/terraform/modules/weblate/app/ecs.tf
+++ b/terraform/modules/weblate/app/ecs.tf
@@ -25,8 +25,8 @@ resource "aws_ecs_service" "weblate" {
   }
 
   timeouts {
-    create = "2m"
-    update = "2m"
+    create = "3m"
+    update = "3m"
   }
   provider = aws.region
 }
@@ -200,6 +200,14 @@ locals {
         {
           name      = "WEBLATE_EMAIL_HOST_PASSWORD",
           valueFrom = var.app_secrets_arns.weblate_email_host_password
+        },
+        {
+          name      = "WEBLATE_GITHUB_USERNAME",
+          valueFrom = "${var.app_secrets_arns.weblate_github}:weblate_github_username::"
+        },
+        {
+          name      = "WEBLATE_GITHUB_TOKEN",
+          valueFrom = "${var.app_secrets_arns.weblate_github}:weblate_github_token::"
         },
       ],
       environment = [

--- a/terraform/modules/weblate/application_logs/cloudwatch_log_group.tf
+++ b/terraform/modules/weblate/application_logs/cloudwatch_log_group.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_query_definition" "app_container_messages" {
   log_group_names = [aws_cloudwatch_log_group.application_logs.name]
 
   query_string = <<EOF
-fields @timestamp, message, concat(method, " ", url) as request, status
+fields @timestamp, @message
 | filter @message not like "ELB-HealthChecker"
 | sort @timestamp desc
 EOF

--- a/terraform/modules/weblate/database.tf
+++ b/terraform/modules/weblate/database.tf
@@ -4,7 +4,7 @@ module "aurora_serverless_v1_postgres" {
   name              = "${local.name_prefix}-postgresql"
   engine            = "aurora-postgresql"
   engine_mode       = "serverless"
-  engine_version    = "11.13"
+  engine_version    = "11.16"
   storage_encrypted = true
 
   vpc_id                = data.aws_vpc.main.id

--- a/terraform/modules/weblate/database.tf
+++ b/terraform/modules/weblate/database.tf
@@ -4,6 +4,7 @@ module "aurora_serverless_v1_postgres" {
   name              = "${local.name_prefix}-postgresql"
   engine            = "aurora-postgresql"
   engine_mode       = "serverless"
+  engine_version    = "11.13"
   storage_encrypted = true
 
   vpc_id                = data.aws_vpc.main.id
@@ -17,12 +18,11 @@ module "aurora_serverless_v1_postgres" {
   skip_final_snapshot  = true
   enable_http_endpoint = true
 
-  db_parameter_group_name         = "default.aurora-postgresql11"
-  db_cluster_parameter_group_name = "default.aurora-postgresql11"
-  create_random_password          = false
-  master_password                 = aws_secretsmanager_secret_version.app_secrets["postgres_password"].secret_string
-  master_username                 = "root"
-  database_name                   = "weblate"
+  db_parameter_group_name = "default.aurora-postgresql11"
+  create_random_password  = false
+  master_password         = aws_secretsmanager_secret_version.app_secrets["postgres_password"].secret_string
+  master_username         = "root"
+  database_name           = "weblate"
   # enabled_cloudwatch_logs_exports = # NOT SUPPORTED
 
   scaling_configuration = {
@@ -36,18 +36,4 @@ module "aurora_serverless_v1_postgres" {
   providers = {
     aws = aws.region
   }
-}
-
-resource "aws_db_parameter_group" "postgresql" {
-  name        = "${local.name_prefix}-aurora-db-postgres-parameter-group"
-  family      = "aurora-postgresql10"
-  description = "${local.name_prefix}-aurora-db-postgres-parameter-group"
-  provider    = aws.region
-}
-
-resource "aws_rds_cluster_parameter_group" "postgresql" {
-  name        = "${local.name_prefix}-aurora-postgres-cluster-parameter-group"
-  family      = "aurora-postgresql10"
-  description = "${local.name_prefix}-aurora-postgres-cluster-parameter-group"
-  provider    = aws.region
 }

--- a/terraform/modules/weblate/ecs.tf
+++ b/terraform/modules/weblate/ecs.tf
@@ -29,14 +29,14 @@ module "app" {
   ecs_capacity_provider          = var.ecs_capacity_provider
   app_env_vars                   = local.weblate_docker_configuration
   app_secrets_arns = {
-    weblate_admin_password         = aws_secretsmanager_secret.app_secrets["weblate_admin_password"].arn
-    weblate_admin_email            = data.aws_secretsmanager_secret.shared_secrets["weblate_admin_email"].arn
-    postgres_password              = aws_secretsmanager_secret.app_secrets["postgres_password"].arn
-    redis_password                 = aws_secretsmanager_secret.app_secrets["redis_password"].arn
-    weblate_email_host_password    = aws_secretsmanager_secret.app_secrets["weblate_email_host_password"].arn
+    weblate_admin_password      = aws_secretsmanager_secret.app_secrets["weblate_admin_password"].arn
+    weblate_admin_email         = data.aws_secretsmanager_secret.shared_secrets["weblate_admin_email"].arn
+    postgres_password           = aws_secretsmanager_secret.app_secrets["postgres_password"].arn
+    redis_password              = aws_secretsmanager_secret.app_secrets["redis_password"].arn
+    weblate_email_host_password = aws_secretsmanager_secret.app_secrets["weblate_email_host_password"].arn
     weblate_gpg_identity        = data.aws_secretsmanager_secret.shared_secrets["weblate_gpg_identity"].arn
-    weblate_github        = data.aws_secretsmanager_secret.shared_secrets["weblate_github"].arn
-    weblate_social_auth_github = data.aws_secretsmanager_secret.shared_secrets["weblate_social_auth_github"].arn
+    weblate_github              = data.aws_secretsmanager_secret.shared_secrets["weblate_github"].arn
+    weblate_social_auth_github  = data.aws_secretsmanager_secret.shared_secrets["weblate_social_auth_github"].arn
   }
   weblate_repository_url          = var.weblate_repository_url
   weblate_container_version       = var.weblate_container_version


### PR DESCRIPTION
# Purpose

Configure github user and token to enable pull request features

Fixes MLPAB-651

## Approach

- pull github credentials from a single secret 
- extend ecs create/update timeout to allow for pulling more secrets

## Learning

- https://docs.weblate.org/en/latest/vcs.html#github-pull-requests
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html
